### PR TITLE
Added attachment trigger to add individual attachment files…

### DIFF
--- a/src/components/com_flexforms/models/forms.php
+++ b/src/components/com_flexforms/models/forms.php
@@ -269,7 +269,7 @@ class FlexformsModelForms extends F0FModel
      */
     protected function attachFiles(array $files, JMail &$mail)
     {
-        JEventDispatcher::getInstance()->trigger('onBeforeFlexformsAttachmentSubmit', array(&$files));
+        JEventDispatcher::getInstance()->trigger('onBeforeFlexformsAddAttachments', array(&$files));
 
         if (count($files))
         {

--- a/src/components/com_flexforms/models/forms.php
+++ b/src/components/com_flexforms/models/forms.php
@@ -144,7 +144,7 @@ class FlexformsModelForms extends F0FModel
             $dispatcher->trigger('onAfterFlexformsParseOwnerEmailtext', array(&$item, &$form, &$data, &$ownerText));
 
             // Attach uploaded files
-            if (count($files) && $item->owner_attachments)
+            if ($item->owner_attachments)
             {
                 $this->attachFiles($files, $ownerMail);
             }
@@ -193,7 +193,7 @@ class FlexformsModelForms extends F0FModel
             $dispatcher->trigger('onAfterFlexformsParseSenderEmailtext', array(&$item, &$form, &$data, $senderText));
 
             // Attach uploaded files
-            if (count($files) && $item->sender_attachments)
+            if ($item->sender_attachments)
             {
                 $this->attachFiles($files, $senderMail);
             }
@@ -269,9 +269,14 @@ class FlexformsModelForms extends F0FModel
      */
     protected function attachFiles(array $files, JMail &$mail)
     {
-        foreach ($files AS $file)
+        JEventDispatcher::getInstance()->trigger('onBeforeFlexformsAttachmentSubmit', array(&$files));
+
+        if (count($files))
         {
-            $mail->addAttachment($file['tmp_name'], $file['name']);
+            foreach ($files as $file)
+            {
+                $mail->addAttachment($file['tmp_name'], $file['name']);
+            }
         }
     }
 }


### PR DESCRIPTION
…not coming from an upload.

Create a FlexForms plugin with this method to add further attachments:

```
public function onBeforeFlexformsAddAttachments(&$files)
{
    // Get file from local server or API call
    $filePath = JPATH_BASE . '/tmp/test.pdf';

    // Create name from file name or set individual name
    $fileName = 'Test PDF FlexForms.pdf';

    // Add the file to the main $files array with an additional existence check
    if (JFile::exists($filePath))
    {
        // Important: tmp_name and name keys must be provided
        $files[] = array('tmp_name' => $filePath, 'name' => $fileName);
    }
}
```
